### PR TITLE
Added a comment to workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -174,6 +174,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}  # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: MyWpfApp.Package\AppPackages\AppPackages.zip
+        asset_path: MyWpfApp.Package\AppPackages\AppPackages.zip  # Use the full path here because environment variables are not in scope
         asset_name: AppPackages.zip
         asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: MSIX Package
-        path: MyWpfApp.Package\AppPackages\
+        path: MyWpfApp.Package\AppPackages\  # Use the full path here because environment variables are not in scope


### PR DESCRIPTION
Added a comment to workflows explaining why it is necessary to use the full path in the jobs.<job_id>.steps.with step of an action.