### PR TITLE
Repair UapAppxPackageBuildMode values

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,7 +128,7 @@ jobs:
       env:
         AppxBundle: Never
         AppInstallerUri: ${{ matrix.DistributionUrl }}
-        BuildMode: SideLoadOnly
+        BuildMode: SideloadOnly
         Configuration: ${{ matrix.Configuration }}
         GenerateAppInstallerFile: True
         TargetPlatform: ${{ matrix.targetplatform }}
@@ -140,7 +140,7 @@ jobs:
       env:
         AppxBundle: Never
         AppxPackageSigningEnabled: False
-        BuildMode: StoreOnly
+        BuildMode: StoreUpload
         Configuration: ${{ matrix.Configuration }}
         GenerateAppInstallerFile: False
         TargetPlatform: ${{ matrix.targetplatform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       run: msbuild $env:Solution_Path /p:Platform=$env:TargetPlatform /p:Configuration=$env:Configuration /p:UapAppxPackageBuildMode=$env:BuildMode /p:AppxBundle=$env:AppxBundle /p:PackageCertificateKeyFile=$env:SigningCertificate /p:PackageCertificatePassword=${{ secrets.Pfx_Key }}
       env:
         AppxBundle: Never
-        BuildMode: SideLoadOnly
+        BuildMode: SideloadOnly
         Configuration: Debug
         TargetPlatform: ${{ matrix.targetplatform }}
 


### PR DESCRIPTION
The msbuild arg for setting the package types, according to the [UWP Packaging Documentation](https://docs.microsoft.com/en-us/windows/uwp/packaging/auto-build-package-uwp-apps) guidance are the following

|Parameter | Value | Description|
-- | -- | --
UapAppxPackageBuildMode | StoreUpload | Generates the .msixupload/.appxupload file and the _Test folder for sideloading. |
UapAppxPackageBuildMode | SideloadOnly | Generates the _Test folder for sideloading only.|
UapAppxPackageBuildMode | CI | Generates the .msixupload/.appxupload file only.|

